### PR TITLE
Ignore development and testing messages from wdb

### DIFF
--- a/src/lib/WdbListener.svelte
+++ b/src/lib/WdbListener.svelte
@@ -11,6 +11,8 @@
 
       stomp.subscribe('/exchange/fp.notifications', (message) => {
         try {
+          // Ignore debugging / development messages
+          if(message.headers.env !== 'prod') return
           const body = JSON.parse(message.body) as WanDb_FloatplaneData;
           floatplaneState.set({
             ...body,


### PR DESCRIPTION
Small change to ensure that development and testing messages don't get picked up by wheniswan and accidentally shown as 'live' when it is in fact just a test