### PR TITLE
Migrate to new TWDB socket server

### DIFF
--- a/src/lib/WdbListener.svelte
+++ b/src/lib/WdbListener.svelte
@@ -4,6 +4,17 @@
   import type { WanDb_FloatplaneData } from "$lib/utils.ts";
   import { floatplaneState, wdbSocketState } from "$lib/stores.ts";
 
+  // This is the message format that the WDB websocket sends to the client
+  interface WdbMessage {
+    live: boolean,
+    wan: boolean,
+    title: string,
+    description: string,
+    thumbnail: string,
+    imminence: 0 | 1 | 2 | 3,
+    textImminence: "Distant" | "Today" | "Soon" | "Imminent"
+  }
+
   let stomp: Client | undefined;
   onMount(() => {
     stomp = webstomp.client('wss://mq.thewandb.com/ws', {debug: false});

--- a/src/lib/WdbListener.svelte
+++ b/src/lib/WdbListener.svelte
@@ -7,7 +7,7 @@
   // This is the message format that the WDB websocket sends to the client
   interface WdbMessage {
     live: boolean,
-    wan: boolean,
+    wan?: boolean,
     title: string,
     description: string,
     thumbnail: string,
@@ -18,16 +18,19 @@
   let stomp: Client | undefined;
   onMount(() => {
     stomp = webstomp.client('wss://mq.thewandb.com/ws', {debug: false});
-    stomp.connect('whenplane', 'cWDK2KUpPCw3AW', () => {
+    stomp.connect({
+        host: 'prod_whenplane_com',
+        login: 'whenplane',
+        passcode: 'cWDK2KUpPCw3AW'
+    }, () => {
 
-      stomp?.subscribe('/exchange/fp.notifications', (message) => {
+      stomp?.subscribe('/exchange/status', (message) => {
         try {
           const body = JSON.parse(message.body) as WdbMessage ;
+          body.isWan = body.wan;
+          delete body.wan;
+          floatplaneState.set(body as WanDb_FloatplaneData);
 
-          floatplaneState.set({
-            ...body,
-            live: !body.offline
-          });
           wdbSocketState.update(value => {
             value.lastReceive = Date.now();
             return value;

--- a/src/lib/WdbListener.svelte
+++ b/src/lib/WdbListener.svelte
@@ -22,9 +22,8 @@
 
       stomp?.subscribe('/exchange/fp.notifications', (message) => {
         try {
-          // Ignore debugging / development messages
-          if(message.headers.env !== 'prod') return
-          const body = JSON.parse(message.body) as WanDb_FloatplaneData;
+          const body = JSON.parse(message.body) as WdbMessage ;
+
           floatplaneState.set({
             ...body,
             live: !body.offline

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -163,12 +163,10 @@ export type FloatplaneSubscription = {
 
 export type WanDb_FloatplaneData = {
     live?: boolean,
-    offline?: boolean
-    id?: string,
     isWAN?: boolean,
     title?: string,
     description?: string,
-    thumbnail?: FloatplaneImage
+    thumbnail?: string
     error?: any
 };
 


### PR DESCRIPTION
This PR (hopefully) makes the changes necessary to bring Whenplane's socket connection back inline with the protocol and formatting of TWDB's socket service. It is not verified to work, but to the best of my knowledge should be "close enough" that it shouldnt run into any issues.