### PR TITLE
[feat] (WIP) - migrate to protocol 0.1.2

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,23 +4,17 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/wan.webp" />
 		<meta name="viewport" content="width=device-width" />
-		<link rel="manifest" href="/site.webmanifest" />
-		<link rel="apple-touch-icon" href="/wan-ios-logo.png" />
+		<link rel="manifest" href="/site.webmanifest">
+		<link rel="apple-touch-icon" href="/wan-ios-logo.png">
 		%sveltekit.head%
 	</head>
 	<body data-theme="crimson" data-sveltekit-preload-code="viewport" data-sveltekit-preload-data>
 		<div style="display: contents">%sveltekit.body%</div>
-		<!-- Cloudflare Web Analytics -->
-		<script
-			defer
-			src="https://static.cloudflareinsights.com/beacon.min.js"
-			data-cf-beacon='{"token": "7449720ccc244298870ba34ef0901bf1"}'
-		></script>
-		<!-- End Cloudflare Web Analytics -->
+		<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "7449720ccc244298870ba34ef0901bf1"}'></script><!-- End Cloudflare Web Analytics -->
 
 		<script>
-			if (location.pathname === '/ltt-time' && new URL(location.href).searchParams.has('frame')) {
-				document.body.classList.add('background-none');
+			if(location.pathname === "/ltt-time" && new URL(location.href).searchParams.has("frame")) {
+				document.body.classList.add("background-none")
 			}
 		</script>
 	</body>

--- a/src/app.html
+++ b/src/app.html
@@ -4,17 +4,23 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/wan.webp" />
 		<meta name="viewport" content="width=device-width" />
-		<link rel="manifest" href="/site.webmanifest">
-		<link rel="apple-touch-icon" href="/wan-ios-logo.png">
+		<link rel="manifest" href="/site.webmanifest" />
+		<link rel="apple-touch-icon" href="/wan-ios-logo.png" />
 		%sveltekit.head%
 	</head>
 	<body data-theme="crimson" data-sveltekit-preload-code="viewport" data-sveltekit-preload-data>
 		<div style="display: contents">%sveltekit.body%</div>
-		<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "7449720ccc244298870ba34ef0901bf1"}'></script><!-- End Cloudflare Web Analytics -->
+		<!-- Cloudflare Web Analytics -->
+		<script
+			defer
+			src="https://static.cloudflareinsights.com/beacon.min.js"
+			data-cf-beacon='{"token": "7449720ccc244298870ba34ef0901bf1"}'
+		></script>
+		<!-- End Cloudflare Web Analytics -->
 
 		<script>
-			if(location.pathname === "/ltt-time" && new URL(location.href).searchParams.has("frame")) {
-				document.body.classList.add("background-none")
+			if (location.pathname === '/ltt-time' && new URL(location.href).searchParams.has('frame')) {
+				document.body.classList.add('background-none');
 			}
 		</script>
 	</body>

--- a/src/lib/WdbListener.svelte
+++ b/src/lib/WdbListener.svelte
@@ -43,6 +43,7 @@
 			console.debug('[wdb] Using WDB Protocol Version: ' + data.version);
 			console.debug('[wdb] WDB Features: ' + data.features);
 			floatplaneState.set(data.state as unknown as WanDb_FloatplaneData);
+			if (!socket) return console.error('[wdb] Socket is undefined - unable to proceeed');
 			socket.emit(
 				'join',
 				JSON.stringify({

--- a/src/lib/WdbListener.svelte
+++ b/src/lib/WdbListener.svelte
@@ -1,73 +1,76 @@
 <script lang="ts">
-  import {onDestroy, onMount} from "svelte";
-  import * as socketio from "socket.io-client";
-  import {floatplaneState, wdbSocketState} from "$lib/stores.ts";
+	import { onDestroy, onMount } from 'svelte';
+	import * as socketio from 'socket.io-client';
+	import { floatplaneState, wdbSocketState } from '$lib/stores.ts';
 
-  import type { WanDb_FloatplaneData } from "$lib/wdb_types.ts";
+	import type { WanDb_FloatplaneData } from '$lib/wdb_types.ts';
 
-  // Interface sent by the WDB websocket on connection
-  interface WdbConnectState {
-    version: string,
-    features: number,
-    state: WdbMessage
-  }
+	// Interface sent by the WDB websocket on connection
+	interface WdbConnectState {
+		version: string;
+		features: number;
+		state: WdbMessage;
+	}
 
-  // This is the message format that the WDB websocket sends to the client
-  interface WdbMessage {
-    live: boolean,
-    isWAN: boolean,
-    isAfterparty: boolean
-    title: string,
-    description: string,
-    thumbnail: {
-      url: string,
-      width: number,
-      height: number
-      childImages: any[]
-    },
-    imminence: 0 | 1 | 2 | 3 | 4,
-    sponsors: any[]
-  }
+	// This is the message format that the WDB websocket sends to the client
+	interface WdbMessage {
+		live: boolean;
+		isWAN: boolean;
+		isAfterparty: boolean;
+		title: string;
+		description: string;
+		thumbnail: {
+			url: string;
+			width: number;
+			height: number;
+			childImages: any[];
+		};
+		imminence: 0 | 1 | 2 | 3 | 4;
+		sponsors: any[];
+	}
 
-  let socket: socketio.Socket | undefined
+	let socket: socketio.Socket | undefined;
 
-  onMount(() => {
-    socket = socketio.connect('wss://mq.thewandb.com', {transports: ['websocket']});
-    socket.on('connect', () => {
-      console.debug("[wdb] Connected to WDB")
-    });
+	onMount(() => {
+		socket = socketio.connect('wss://mq.thewandb.com', { transports: ['websocket'] });
+		socket.on('connect', () => {
+			console.debug('[wdb] Connected to WDB');
+		});
 
-    // Handle the connection message (which includes initial state)
-    socket.on("state_sync", (data: WdbConnectState) => {
-      console.debug("[wdb] Received State Sync message")
-      console.debug("[wdb] Using WDB Protocol Version: " + data.version)
-      console.debug("[wdb] WDB Features: " + data.features)
-      floatplaneState.set(data.state as WanDb_FloatplaneData);
-      socket.emit('join', JSON.stringify({
-        id: 'live'
-      }));
-    });
+		// Handle the connection message (which includes initial state)
+		socket.on('state_sync', (data: WdbConnectState) => {
+			console.debug('[wdb] Received State Sync message');
+			console.debug('[wdb] Using WDB Protocol Version: ' + data.version);
+			console.debug('[wdb] WDB Features: ' + data.features);
+			floatplaneState.set(data.state as unknown as WanDb_FloatplaneData);
+			socket.emit(
+				'join',
+				JSON.stringify({
+					id: 'live'
+				})
+			);
+		});
 
-    // Handle the live state updates (revised for protocol 0.1.2)
-    socket.on('live', (message: string) => {
-      const body = JSON.parse(message) as WdbMessage;
-      floatplaneState.set(body as WanDb_FloatplaneData);
+		// Handle the live state updates (revised for protocol 0.1.2)
+		socket.on('live', (message: string) => {
+			const body = JSON.parse(message) as WdbMessage;
+			floatplaneState.set(body as unknown as WanDb_FloatplaneData);
 
-      wdbSocketState.update(value => {
-        value.lastReceive = Date.now();
-        return value;
-      });
-    });
+			wdbSocketState.update((value) => {
+				value.lastReceive = Date.now();
+				return value;
+			});
+		});
 
-    socket.on('disconnect', (code: number) => {
-      console.debug("[wdb] Disconnected from WDB (with code: " + code + ")");
-    })
-  })
+		socket.on('disconnect', (code: number) => {
+			console.debug('[wdb] Disconnected from WDB (with code: ' + code + ')');
+		});
+	});
 
-  onDestroy(() => {
-    if (socket) {
-      socket.disconnect();
-      socket = undefined;
-    }
-  })
+	onDestroy(() => {
+		if (socket) {
+			socket.disconnect();
+			socket = undefined;
+		}
+	});
 </script>

--- a/src/lib/wdb_types.ts
+++ b/src/lib/wdb_types.ts
@@ -1,77 +1,76 @@
 export type WanDb_FloatplaneData = {
-  live?: boolean,
-  isWAN?: boolean,
-  title?: string,
-  description?: string,
-  thumbnail?: string
-  error?: any,
-  imminence?: number,
-  textImminence?: string
+	live?: boolean;
+	isWAN?: boolean;
+	isAfterparty?: boolean;
+	title?: string;
+	description?: string;
+	thumbnail?: string;
+	error?: any;
+	imminence?: number;
+	textImminence?: string;
 };
 
 export type WanDb_SocketState = {
-  lastReceive: number
-}
+	lastReceive: number;
+};
 
 export type WanDb_Episode = {
-  id: string,
-  floatplane: string,
-  title: string,
-  description: string,
-  thumbnail: string,
-  aired: string,
-  duration: number,
-  topicCount: number,
-  hostCount: number,
-  sponsorCount: number,
-  merchMessageCount: number,
-  introStart: number | null,
-  introDuration: number | null,
-  preShowOffset: number,
-  errors: string[],
-  cast: unknown[],
-  products: unknown[],
-  merchMessages: unknown[],
-  topics: WanDb_Topic[],
-  sponsors: WanDb_Sponsor[]
-}
+	id: string;
+	floatplane: string;
+	title: string;
+	description: string;
+	thumbnail: string;
+	aired: string;
+	duration: number;
+	topicCount: number;
+	hostCount: number;
+	sponsorCount: number;
+	merchMessageCount: number;
+	introStart: number | null;
+	introDuration: number | null;
+	preShowOffset: number;
+	errors: string[];
+	cast: unknown[];
+	products: unknown[];
+	merchMessages: unknown[];
+	topics: WanDb_Topic[];
+	sponsors: WanDb_Sponsor[];
+};
 
 export type WanDb_Topic = {
-  id: string,
-  episodeId: string,
-  title: string,
-  parent: string | null,
-  start: number,
-  end: number,
-  created: string,
-  ref: unknown | null,
-  kind: string,
-  modified: string,
-  children?: WanDb_Topic[]
-}
+	id: string;
+	episodeId: string;
+	title: string;
+	parent: string | null;
+	start: number;
+	end: number;
+	created: string;
+	ref: unknown | null;
+	kind: string;
+	modified: string;
+	children?: WanDb_Topic[];
+};
 
 export type WanDb_Sponsor = {
-  id: string,
-  message: string,
-  url: string | null,
-  added: string,
-  modified: string,
-  companyId: string,
-  isDennis: boolean,
-  start: number,
-  end: number,
-  safe: boolean
-  episodeId: string,
-  isSponsorDebut: boolean,
-  company: {
-    id: string,
-    name: string,
-    links: unknown[],
-    logo: unknown | null,
-    founded: unknown | null,
-    added: string,
-    modified: string
-  }
-}
-
-
+	id: string;
+	message: string;
+	url: string | null;
+	added: string;
+	modified: string;
+	companyId: string;
+	isDennis: boolean;
+	start: number;
+	end: number;
+	safe: boolean;
+	episodeId: string;
+	isSponsorDebut: boolean;
+	company: {
+		id: string;
+		name: string;
+		links: unknown[];
+		logo: unknown | null;
+		founded: unknown | null;
+		added: string;
+		modified: string;
+	};
+};


### PR DESCRIPTION
This migrates the existing WanDB socket implementation to use the more up-to-date protocol 0.1.2, which allows for immediate state-sync on connection, as well as protections to prevent incompatible protocols crashing an application.

It also preemptively changes to using the `live` event, over the soon to be retired `state` event for Floatplane state updates
