### PR TITLE
remove About link in bottom right

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -412,10 +412,6 @@
 			</a>
 		</span>
 	</div>
-{:else}
-	<div class="absolute bottom-0 right-0 p-2">
-		<a href="/about">About</a>
-	</div>
 {/if}
 
 {#if !isFrame}


### PR DESCRIPTION
Removed About link in bottom right hand corner for all users per issue #22 
Since About & Preferences in the drop down makes it redundant I figured this would be fine.